### PR TITLE
Create unified platformio.ini with three build environments

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -11,9 +11,15 @@
 [env]
 upload_speed = 921600
 monitor_speed = 115200 ; must remain at 115200 for improv
-;monitor_speed = 74880  ; hardware default
 board_build.filesystem = littlefs
+extra_scripts =
+    build_flags.py
+    pre:build_web_content.py
+    pre:auto_firmware_version.py
 
+; ================================================================================
+; ESP8266 Environment - Original RATGDO with Arduino-HomeKit-ESP8266
+; ================================================================================
 [env:ratgdo_esp8266_hV25]
 framework = arduino
 platform = espressif8266
@@ -24,12 +30,13 @@ build_flags =
     -llwip2-536
     ${env.build_flags}
     '-Wno-unused-variable'
+    -D ESP8266
     -D PIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY_LOW_FLASH
     -D PIO_FRAMEWORK_ARDUINO_MMU_CACHE16_IRAM48_SECHEAP_SHARED
-    ;-D USE_NTP_TIMESTAMP
     -D HOMEKIT_USE_IRAM
     -D HOMEKIT_USE_RATGDO_LOG
     -D GW_PING_CHECK
+    ;-D USE_NTP_TIMESTAMP
     ;-D CRASH_DEBUG
     ;-D DEBUG_UPDATER=Serial
 monitor_filters = esp8266_exception_decoder
@@ -41,10 +48,63 @@ lib_deps =
     dancol90/ESP8266Ping@^1.1.0
     https://github.com/mathertel/OneButton#2.6.1
 lib_ldf_mode = deep+
-extra_scripts =
-    build_flags.py
-    pre:build_web_content.py
-    pre:auto_firmware_version.py
+
+; ================================================================================
+; ESP32 Environment with GDOLIB - Uses HomeSpan and GDOLIB for door comms
+; ================================================================================
+[env:ratgdo_esp32_gdolib]
+framework = arduino
+platform = espressif32
+board = esp32dev
+board_build.partitions = min_spiffs.csv
+build_flags =
+    ${env.build_flags}
+    '-Wno-unused-variable'
+    -D ESP32
+    -D USE_GDOLIB
+    -D HOMEKIT_USE_RATGDO_LOG
+    -D GW_PING_CHECK
+    ;-D USE_NTP_TIMESTAMP
+    ;-D CRASH_DEBUG
+    ;-D DEBUG_UPDATER=Serial
+monitor_filters = esp32_exception_decoder
+lib_deps =
+    homespan/HomeSpan@^1.9.0
+    https://github.com/jgstroud/EspSaveCrash.git#cf2803abfa51a83c93548f2591d4564a47845a72
+    esphome/Improv@^1.2.3
+    https://github.com/dkerr64/GDOLIB.git#sw-serial
+    mathertel/OneButton@^2.6.1
+lib_ldf_mode = deep+
+
+; ================================================================================
+; ESP32 Environment without GDOLIB - Uses HomeSpan but original comms implementation
+; ================================================================================
+[env:ratgdo_esp32_no_gdolib]
+framework = arduino
+platform = espressif32
+board = esp32dev
+board_build.partitions = min_spiffs.csv
+build_flags =
+    ${env.build_flags}
+    '-Wno-unused-variable'
+    -D ESP32
+    -D HOMEKIT_USE_RATGDO_LOG
+    -D GW_PING_CHECK
+    ;-D USE_NTP_TIMESTAMP
+    ;-D CRASH_DEBUG
+    ;-D DEBUG_UPDATER=Serial
+monitor_filters = esp32_exception_decoder
+lib_deps =
+    homespan/HomeSpan@^1.9.0
+    https://github.com/jgstroud/EspSaveCrash.git#cf2803abfa51a83c93548f2591d4564a47845a72
+    esphome/Improv@^1.2.3
+    https://github.com/ratgdo/espsoftwareserial.git#autobaud
+    mathertel/OneButton@^2.6.1
+lib_ldf_mode = deep+
+
+; ================================================================================
+; Test environments
+; ================================================================================
 
 ; Test environment for rollover testing
 [env:test_rollover]
@@ -57,12 +117,11 @@ build_flags =
     -llwip2-536
     ${env.build_flags}
     '-Wno-unused-variable'
+    -D ESP8266
     -D PIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY_LOW_FLASH
     -D PIO_FRAMEWORK_ARDUINO_MMU_CACHE16_IRAM48_SECHEAP_SHARED
-    ;-D USE_NTP_TIMESTAMP
     -D HOMEKIT_USE_IRAM
     -D GW_PING_CHECK
-    ;-D CRASH_DEBUG
     -D TEST_ROLLOVER  ; Enable rollover testing
 lib_deps =
     https://github.com/dkerr64/Arduino-HomeKit-ESP8266.git#77cbbe278d2f0c8812c66ddd623b8eb84fe1a2d6
@@ -72,10 +131,6 @@ lib_deps =
     dancol90/ESP8266Ping@^1.1.0
     mathertel/OneButton@^2.6.1
 lib_ldf_mode = deep+
-extra_scripts =
-    build_flags.py
-    pre:build_web_content.py
-    pre:auto_firmware_version.py
 
 ; Native testing environment
 [env:native]
@@ -153,33 +208,14 @@ test_framework = unity
 lib_deps = Unity
 test_filter = test_hardware
 
-; ESP8266 alias for compatibility
+; ================================================================================
+; Aliases for backward compatibility
+; ================================================================================
 [env:esp8266]
-framework = arduino
-platform = espressif8266
-board = d1_mini
-board_build.ldscript = eagle.flash.4m2m.ld
-build_flags =
-    -Llib/lwip2
-    -llwip2-536
-    ${env.build_flags}
-    '-Wno-unused-variable'
-    -D PIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY_LOW_FLASH
-    -D PIO_FRAMEWORK_ARDUINO_MMU_CACHE16_IRAM48_SECHEAP_SHARED
-    ;-D USE_NTP_TIMESTAMP
-    -D HOMEKIT_USE_IRAM
-    -D GW_PING_CHECK
-    ;-D CRASH_DEBUG
-lib_deps =
-    https://github.com/dkerr64/Arduino-HomeKit-ESP8266.git#77cbbe278d2f0c8812c66ddd623b8eb84fe1a2d6
-    https://github.com/jgstroud/EspSaveCrash.git#cf2803abfa51a83c93548f2591d4564a47845a72
-    esphome/Improv@^1.2.3
-    https://github.com/ratgdo/espsoftwareserial.git#autobaud
-    dancol90/ESP8266Ping@^1.1.0
-    mathertel/OneButton@^2.6.1
-lib_ldf_mode = deep+
-extra_scripts =
-    build_flags.py
-    pre:build_web_content.py
-    pre:auto_firmware_version.py
+extends = env:ratgdo_esp8266_hV25
 
+[env:esp32]
+extends = env:ratgdo_esp32_gdolib
+
+[env:esp32_no_gdolib]
+extends = env:ratgdo_esp32_no_gdolib


### PR DESCRIPTION
## Summary
- Created a unified platformio.ini that can build all three firmware versions
- ESP8266 with Arduino-HomeKit-ESP8266
- ESP32 with HomeSpan + GDOLIB
- ESP32 with HomeSpan using original comms implementation

## Changes
- Added three distinct build environments: `ratgdo_esp8266_hV25`, `ratgdo_esp32_gdolib`, `ratgdo_esp32_no_gdolib`
- Configured proper build flags for conditional compilation (`-D ESP8266`, `-D ESP32`, `-D USE_GDOLIB`)
- Set up appropriate library dependencies for each platform
- Added backward compatibility aliases for existing build scripts
- Consolidated common settings in base `[env]` section

## Building
```bash
# Build ESP8266 version
pio run -e ratgdo_esp8266_hV25

# Build ESP32 with GDOLIB
pio run -e ratgdo_esp32_gdolib

# Build ESP32 without GDOLIB
pio run -e ratgdo_esp32_no_gdolib
```

## Notes
- ESP8266 build tested and compiles successfully
- ESP32 builds ready for when source files have proper conditional compilation directives
- This provides the build infrastructure needed while you work on unifying HomeKit.cpp and comms.cpp